### PR TITLE
```

### DIFF
--- a/src/components/magicui/spinning-text.tsx
+++ b/src/components/magicui/spinning-text.tsx
@@ -20,7 +20,7 @@ type SpinningTextProps = {
 
 const BASE_TRANSITION = {
   repeat: Infinity,
-  ease: "linear",
+  ease: "linear" as const,
 };
 
 const BASE_ITEM_VARIANTS = {


### PR DESCRIPTION
fix(magicui): 修复 SpinningText 组件中的类型错误

将 ease 属性的值从字符串字面量改为 const 断言，
以确保 TypeScript 类型检查通过并保持动画行为一致。
```